### PR TITLE
Add Slack AI assistant project scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+.env.local
+.DS_Store

--- a/slack-ai-app/.env.example
+++ b/slack-ai-app/.env.example
@@ -1,0 +1,12 @@
+# Slack credentials
+SLACK_BOT_TOKEN=xoxb-your-bot-token
+SLACK_SIGNING_SECRET=your-signing-secret
+SLACK_APP_TOKEN=xapp-your-app-level-token
+
+# OpenAI
+OPENAI_API_KEY=sk-your-openai-key
+
+# Optional configuration
+MODEL=gpt-4o-mini
+SYSTEM_PROMPT=You are a helpful Slack assistant that provides concise, actionable answers.
+MAX_TOKENS=600

--- a/slack-ai-app/README.md
+++ b/slack-ai-app/README.md
@@ -1,0 +1,82 @@
+# Slack AI Assistant
+
+This project scaffolds a Slack app that uses the Slack Bolt framework together with the OpenAI API to deliver AI-assisted conversations directly in Slack. It comes with a simple event-driven architecture, development tooling, and guidance on how to configure secrets for local development.
+
+## Features
+
+- Responds to channel messages and `/ask-ai` slash command with OpenAI-powered answers
+- Built with the [Slack Bolt](https://slack.dev/bolt-js) framework and the official [OpenAI Node SDK](https://github.com/openai/openai-node)
+- Structured handlers and services to keep your AI logic modular
+- Uses Socket Mode for local development without setting up a public URL
+
+## Project Structure
+
+```
+slack-ai-app/
+├── package.json
+├── README.md
+├── .env.example
+└── src
+    ├── index.js
+    ├── handlers
+    │   └── messageHandler.js
+    └── services
+        └── openAiClient.js
+```
+
+- `src/index.js` wires the Slack Bolt app, registers event handlers, and starts the app.
+- `src/handlers/messageHandler.js` contains the chat message and slash command logic.
+- `src/services/openAiClient.js` exports a convenience wrapper around the OpenAI chat completion API.
+
+## Getting Started
+
+1. **Install dependencies**
+
+   ```bash
+   npm install
+   ```
+
+2. **Duplicate the environment template**
+
+   ```bash
+   cp .env.example .env
+   ```
+
+3. **Fill in the required environment variables**
+
+   - `SLACK_BOT_TOKEN`
+   - `SLACK_SIGNING_SECRET`
+   - `SLACK_APP_TOKEN`
+   - `OPENAI_API_KEY`
+
+   These should match the credentials from your Slack app configuration and OpenAI account.
+
+4. **Run the development server**
+
+   ```bash
+   npm run dev
+   ```
+
+   This uses Socket Mode, so you do not need to expose a public URL. Make sure Socket Mode is enabled in your Slack app configuration.
+
+5. **Deploying**
+
+   For production deployments, disable Socket Mode and provide a public URL for Slack requests or host the app in an environment where Socket Mode is supported.
+
+## Environment Variables
+
+See `.env.example` for the full list of supported variables. The Bolt app accepts optional tuning parameters:
+
+- `MODEL` – Override the default OpenAI chat model (defaults to `gpt-4o-mini`).
+- `SYSTEM_PROMPT` – Custom system message to steer the assistant behaviour.
+- `MAX_TOKENS` – Maximum number of tokens to generate in responses.
+
+## Extending the App
+
+- Add new handlers in `src/handlers` and register them in `src/index.js`.
+- Use the OpenAI client wrapper to add tools such as function calling or embeddings.
+- Implement persistence for conversation history or user preferences.
+
+## License
+
+MIT

--- a/slack-ai-app/package.json
+++ b/slack-ai-app/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "slack-ai-assistant",
+  "version": "0.1.0",
+  "description": "Slack app scaffold that connects Slack Bolt with OpenAI for AI-assisted conversations.",
+  "main": "src/index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node src/index.js",
+    "dev": "nodemon src/index.js"
+  },
+  "keywords": [
+    "slack",
+    "bolt",
+    "openai",
+    "chatbot",
+    "ai"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@slack/bolt": "^3.17.1",
+    "dotenv": "^16.4.5",
+    "openai": "^4.58.1"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.4"
+  }
+}

--- a/slack-ai-app/src/handlers/messageHandler.js
+++ b/slack-ai-app/src/handlers/messageHandler.js
@@ -1,0 +1,54 @@
+import { getChatCompletion } from '../services/openAiClient.js';
+
+function buildContextFromThread(threadMessages = []) {
+  return threadMessages.map((msg) => ({
+    role: msg.user === 'assistant' ? 'assistant' : 'user',
+    content: msg.text ?? ''
+  }));
+}
+
+export function registerMessageHandler(app) {
+  app.message(async ({ message, client, say, logger }) => {
+    try {
+      if (message.subtype && message.subtype !== 'bot_message') {
+        return;
+      }
+
+      const threadTs = message.thread_ts ?? message.ts;
+      const threadResponse = await client.conversations.replies({
+        channel: message.channel,
+        ts: threadTs,
+        inclusive: true
+      });
+
+      const context = buildContextFromThread(threadResponse.messages ?? []);
+      const responseText = await getChatCompletion({ userMessage: message.text, context });
+
+      await say({
+        text: responseText,
+        thread_ts: threadTs
+      });
+    } catch (error) {
+      logger.error(error);
+      await say({
+        text: "I ran into an error generating a response. Please check the server logs for more details.",
+        thread_ts: message.ts
+      });
+    }
+  });
+
+  app.command('/ask-ai', async ({ ack, respond, command, logger }) => {
+    await ack();
+
+    try {
+      const responseText = await getChatCompletion({ userMessage: command.text });
+      await respond({ text: responseText, response_type: 'in_channel' });
+    } catch (error) {
+      logger.error(error);
+      await respond({
+        text: 'Something went wrong when talking to OpenAI. Please try again later.',
+        response_type: 'ephemeral'
+      });
+    }
+  });
+}

--- a/slack-ai-app/src/index.js
+++ b/slack-ai-app/src/index.js
@@ -1,0 +1,33 @@
+import { App, LogLevel } from '@slack/bolt';
+import { config } from 'dotenv';
+import { registerMessageHandler } from './handlers/messageHandler.js';
+
+config();
+
+if (!process.env.SLACK_BOT_TOKEN || !process.env.SLACK_SIGNING_SECRET) {
+  throw new Error('Missing Slack credentials. Please set SLACK_BOT_TOKEN and SLACK_SIGNING_SECRET.');
+}
+
+const app = new App({
+  token: process.env.SLACK_BOT_TOKEN,
+  signingSecret: process.env.SLACK_SIGNING_SECRET,
+  socketMode: true,
+  appToken: process.env.SLACK_APP_TOKEN,
+  logLevel: process.env.NODE_ENV === 'production' ? LogLevel.INFO : LogLevel.DEBUG
+});
+
+registerMessageHandler(app);
+
+async function start() {
+  const port = Number(process.env.PORT ?? 3000);
+
+  await app.start(port);
+  // eslint-disable-next-line no-console
+  console.log(`⚡️ Slack AI Assistant is running on port ${port}`);
+}
+
+start().catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error('Failed to start Slack AI Assistant', error);
+  process.exit(1);
+});

--- a/slack-ai-app/src/services/openAiClient.js
+++ b/slack-ai-app/src/services/openAiClient.js
@@ -1,0 +1,40 @@
+import { config } from 'dotenv';
+import { OpenAI } from 'openai';
+
+config();
+
+const defaultModel = process.env.MODEL ?? 'gpt-4o-mini';
+const defaultSystemPrompt =
+  process.env.SYSTEM_PROMPT ??
+  'You are a helpful assistant that responds with clear, concise answers and actionable guidance.';
+const defaultMaxTokens = process.env.MAX_TOKENS ? Number(process.env.MAX_TOKENS) : 600;
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+export async function getChatCompletion({ userMessage, context = [] }) {
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error('OPENAI_API_KEY is not set.');
+  }
+
+  const messages = [
+    { role: 'system', content: defaultSystemPrompt },
+    ...context,
+    { role: 'user', content: userMessage }
+  ];
+
+  const response = await client.responses.create({
+    model: defaultModel,
+    input: messages,
+    max_output_tokens: defaultMaxTokens
+  });
+
+  const messageContent = response.output?.[0]?.content;
+  const text = Array.isArray(messageContent)
+    ? messageContent
+        .filter((item) => item.type === 'output_text' && item.text)
+        .map((item) => item.text)
+        .join('\n')
+    : undefined;
+
+  return text ?? 'I was unable to generate a response. Please try again.';
+}


### PR DESCRIPTION
## Summary
- add a new `slack-ai-app` workspace scaffold that connects Slack Bolt with OpenAI
- include modular handler and service structure for message replies and `/ask-ai` command
- document setup steps, environment variables, and ignore local-only artifacts

## Testing
- npm install *(fails: npm registry access is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7bf9dc9c833191bf4375748c260f
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a new Slack app scaffold that connects Slack Bolt to OpenAI for assistant-style replies. It handles channel messages and a /ask-ai command, and uses Socket Mode for local development.

- **New Features**
  - Modular handlers and services (message handler + OpenAI client).
  - Thread-aware replies by building context from conversation history.
  - Env template and README with model, prompt, and max token defaults.
  - Dev scripts (start, nodemon) and .gitignore for local artifacts.

- **Migration**
  - Copy .env.example to .env and set Slack and OpenAI keys.
  - Enable Socket Mode and provide an App-Level Token.
  - Install dependencies and run npm run dev.

<!-- End of auto-generated description by cubic. -->

