### PR TITLE
Update channel property for thread replies

### DIFF
--- a/slack-ai-app/src/handlers/messageHandler.js
+++ b/slack-ai-app/src/handlers/messageHandler.js
@@ -16,7 +16,7 @@ export function registerMessageHandler(app) {
 
       const threadTs = message.thread_ts ?? message.ts;
       const threadResponse = await client.conversations.replies({
-        channel: message.channel,
+        channel: message.channels,
         ts: threadTs,
         inclusive: true
       });


### PR DESCRIPTION
## Summary
- use `message.channels` when requesting thread replies to match the updated payload shape

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deb3fd60c08331a04953a76ab16880
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switch thread replies request to use message.channels instead of message.channel to match the updated payload shape. This prevents failures when fetching replies and keeps the handler compatible with the new event payload.

<!-- End of auto-generated description by cubic. -->

