### PR TITLE
Add summary section to root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
 # test-repo 👀
+
+## Summary
+
+This repository is a Next.js project that also includes a **Slack AI Assistant** (`slack-ai-app/`). The Slack app is built with the [Slack Bolt](https://slack.dev/bolt-js) framework and the [OpenAI Node SDK](https://github.com/openai/openai-node) to deliver AI-powered conversations directly in Slack channels. It responds to messages and a `/ask-ai` slash command using OpenAI chat completions, and supports Socket Mode for local development. The Next.js frontend uses shadcn/ui components and Tailwind CSS for styling.
+
+See [`slack-ai-app/README.md`](slack-ai-app/README.md) for detailed setup and usage instructions for the Slack bot.
+
+---
+
 Testing woohoo!
 Another test
 Another one


### PR DESCRIPTION
Added a Summary section to the root `README.md` that describes the two main parts of the repository: the Next.js frontend (shadcn/ui + Tailwind CSS) and the Slack AI Assistant sub-project (Slack Bolt + OpenAI SDK). Includes a link to the detailed `slack-ai-app/README.md` for setup instructions.

<a href="https://slack.com/archives/C033JDYBXNV/p1771015383436979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0.app/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0.app/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0.app/chat-static/slack-light.svg" width="108" height="30"></picture></a>