### PR TITLE
Add login page with split-panel layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,125 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --font-sans: var(--font-inter);
+  --font-mono: var(--font-geist-mono);
+}
+
+:root {
+  --radius: 0.625rem;
+  --background: oklch(0.98 0.005 240);
+  --foreground: oklch(0.15 0.02 240);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.15 0.02 240);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.15 0.02 240);
+  --primary: oklch(0.45 0.18 250);
+  --primary-foreground: oklch(0.98 0.005 240);
+  --secondary: oklch(0.94 0.01 240);
+  --secondary-foreground: oklch(0.25 0.02 240);
+  --muted: oklch(0.94 0.01 240);
+  --muted-foreground: oklch(0.5 0.02 240);
+  --accent: oklch(0.94 0.01 240);
+  --accent-foreground: oklch(0.25 0.02 240);
+  --destructive: oklch(0.55 0.2 27);
+  --destructive-foreground: oklch(0.98 0.005 240);
+  --border: oklch(0.88 0.01 240);
+  --input: oklch(0.88 0.01 240);
+  --ring: oklch(0.45 0.18 250);
+  --chart-1: oklch(0.55 0.18 250);
+  --chart-2: oklch(0.6 0.15 170);
+  --chart-3: oklch(0.55 0.12 70);
+  --chart-4: oklch(0.6 0.17 310);
+  --chart-5: oklch(0.65 0.18 30);
+  --sidebar: oklch(0.97 0.005 240);
+  --sidebar-foreground: oklch(0.15 0.02 240);
+  --sidebar-primary: oklch(0.45 0.18 250);
+  --sidebar-primary-foreground: oklch(0.98 0.005 240);
+  --sidebar-accent: oklch(0.94 0.01 240);
+  --sidebar-accent-foreground: oklch(0.25 0.02 240);
+  --sidebar-border: oklch(0.88 0.01 240);
+  --sidebar-ring: oklch(0.45 0.18 250);
+}
+
+.dark {
+  --background: oklch(0.12 0.02 250);
+  --foreground: oklch(0.93 0.005 240);
+  --card: oklch(0.17 0.02 250);
+  --card-foreground: oklch(0.93 0.005 240);
+  --popover: oklch(0.17 0.02 250);
+  --popover-foreground: oklch(0.93 0.005 240);
+  --primary: oklch(0.55 0.2 250);
+  --primary-foreground: oklch(0.98 0.005 240);
+  --secondary: oklch(0.22 0.02 250);
+  --secondary-foreground: oklch(0.88 0.01 240);
+  --muted: oklch(0.22 0.02 250);
+  --muted-foreground: oklch(0.6 0.02 240);
+  --accent: oklch(0.22 0.02 250);
+  --accent-foreground: oklch(0.88 0.01 240);
+  --destructive: oklch(0.55 0.2 27);
+  --destructive-foreground: oklch(0.98 0.005 240);
+  --border: oklch(0.28 0.02 250);
+  --input: oklch(0.28 0.02 250);
+  --ring: oklch(0.55 0.2 250);
+  --chart-1: oklch(0.55 0.2 250);
+  --chart-2: oklch(0.6 0.15 170);
+  --chart-3: oklch(0.55 0.12 70);
+  --chart-4: oklch(0.6 0.17 310);
+  --chart-5: oklch(0.65 0.18 30);
+  --sidebar: oklch(0.14 0.02 250);
+  --sidebar-foreground: oklch(0.93 0.005 240);
+  --sidebar-primary: oklch(0.55 0.2 250);
+  --sidebar-primary-foreground: oklch(0.98 0.005 240);
+  --sidebar-accent: oklch(0.22 0.02 250);
+  --sidebar-accent-foreground: oklch(0.88 0.01 240);
+  --sidebar-border: oklch(0.28 0.02 250);
+  --sidebar-ring: oklch(0.55 0.2 250);
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next"
+import { Inter, JetBrains_Mono } from "next/font/google"
+import "./globals.css"
+
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-inter",
+})
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  variable: "--font-geist-mono",
+})
+
+export const metadata: Metadata = {
+  title: "Slack AI App",
+  description: "AI-powered Slack assistant for your team",
+}
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
+      <body className="font-sans antialiased">{children}</body>
+    </html>
+  )
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,80 @@
+import { LoginForm } from "@/components/login-form"
+
+export const metadata = {
+  title: "Sign In - Slack AI App",
+  description: "Sign in to your Slack AI App account",
+}
+
+export default function LoginPage() {
+  return (
+    <div className="grid min-h-svh lg:grid-cols-2">
+      {/* Left panel - Form */}
+      <div className="flex flex-col justify-center px-6 py-12 lg:px-16 xl:px-24">
+        <div className="mx-auto w-full max-w-sm">
+          {/* Logo & heading */}
+          <div className="flex flex-col gap-2 mb-8">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary">
+                <svg
+                  className="h-5 w-5 text-primary-foreground"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth="2"
+                  stroke="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M8.625 9.75a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375m-13.5 3.01c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.184-4.183a1.14 1.14 0 0 1 .778-.332 48.294 48.294 0 0 0 5.83-.498c1.585-.233 2.708-1.626 2.708-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"
+                  />
+                </svg>
+              </div>
+              <span className="text-lg font-semibold text-foreground">Slack AI</span>
+            </div>
+            <h1 className="text-2xl font-bold tracking-tight text-foreground text-balance">
+              Welcome back
+            </h1>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              Sign in to your account to continue managing your AI-powered Slack assistant.
+            </p>
+          </div>
+
+          <LoginForm />
+        </div>
+      </div>
+
+      {/* Right panel - Decorative */}
+      <div className="relative hidden lg:block bg-primary">
+        <div className="absolute inset-0 flex flex-col items-center justify-center px-16">
+          <div className="max-w-md text-center">
+            <div className="mb-8 flex justify-center">
+              <div className="rounded-2xl bg-primary-foreground/10 p-6 backdrop-blur-sm">
+                <svg
+                  className="h-16 w-16 text-primary-foreground"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth="1.5"
+                  stroke="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 0 0-2.455 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <blockquote className="text-xl font-medium text-primary-foreground leading-relaxed mb-4 text-balance">
+              {'"Supercharge your team\'s productivity with AI that lives right where you work."'}
+            </blockquote>
+            <p className="text-sm text-primary-foreground/70">
+              Smart replies, summaries, and insights — all inside Slack.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation"
+
+export default function Home() {
+  redirect("/login")
+}

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -1,0 +1,146 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Checkbox } from "@/components/ui/checkbox"
+
+export function LoginForm() {
+  const [isLoading, setIsLoading] = useState(false)
+  const [showPassword, setShowPassword] = useState(false)
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setIsLoading(true)
+    // Simulate login - replace with real auth
+    await new Promise((resolve) => setTimeout(resolve, 1500))
+    setIsLoading(false)
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="email" className="text-sm font-medium text-foreground">
+          Email address
+        </Label>
+        <Input
+          id="email"
+          type="email"
+          placeholder="you@company.com"
+          required
+          disabled={isLoading}
+          className="h-11 bg-background border-border px-4 text-foreground placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <Label htmlFor="password" className="text-sm font-medium text-foreground">
+            Password
+          </Label>
+          <a
+            href="#"
+            className="text-sm font-medium text-primary hover:text-primary/80 transition-colors"
+          >
+            Forgot password?
+          </a>
+        </div>
+        <Input
+          id="password"
+          type={showPassword ? "text" : "password"}
+          placeholder="Enter your password"
+          required
+          disabled={isLoading}
+          className="h-11 bg-background border-border px-4 text-foreground placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id="show-password"
+          checked={showPassword}
+          onCheckedChange={(checked) => setShowPassword(checked === true)}
+        />
+        <Label htmlFor="show-password" className="text-sm text-muted-foreground cursor-pointer">
+          Show password
+        </Label>
+      </div>
+
+      <Button
+        type="submit"
+        disabled={isLoading}
+        className="h-11 w-full font-medium text-sm"
+      >
+        {isLoading ? (
+          <span className="flex items-center gap-2">
+            <svg
+              className="animate-spin h-4 w-4"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+            Signing in...
+          </span>
+        ) : (
+          "Sign in"
+        )}
+      </Button>
+
+      <div className="relative flex items-center gap-4 py-2">
+        <div className="flex-1 h-px bg-border" />
+        <span className="text-xs text-muted-foreground uppercase tracking-wider">or</span>
+        <div className="flex-1 h-px bg-border" />
+      </div>
+
+      <Button
+        type="button"
+        variant="outline"
+        className="h-11 w-full font-medium text-sm gap-3 border-border text-foreground hover:bg-accent"
+        disabled={isLoading}
+      >
+        <svg className="h-5 w-5" viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.76h3.56c2.08-1.92 3.28-4.74 3.28-8.09z"
+            fill="#4285F4"
+          />
+          <path
+            d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.56-2.76c-.98.66-2.23 1.06-3.72 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+            fill="#34A853"
+          />
+          <path
+            d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+            fill="#FBBC05"
+          />
+          <path
+            d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+            fill="#EA4335"
+          />
+        </svg>
+        Continue with Google
+      </Button>
+
+      <p className="text-center text-sm text-muted-foreground">
+        {"Don't have an account? "}
+        <a href="#" className="font-medium text-primary hover:text-primary/80 transition-colors">
+          Sign up
+        </a>
+      </p>
+    </form>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+	"dependencies": {
+		"tw-animate-css": "^1.4.0"
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,22 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
+
+packages:
+
+  tw-animate-css@1.4.0:
+    resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
+
+snapshots:
+
+  tw-animate-css@1.4.0: {}


### PR DESCRIPTION
Adds a login page for the Slack AI App with a clean split-panel design.

### What changed
- Created `/app/login/page.tsx` with a two-column layout: login form on the left, branded decorative panel on the right
- Built `LoginForm` component with email/password fields, show-password toggle, loading state with spinner, Google OAuth button, and sign-up link
- Set up root layout with Inter and JetBrains Mono fonts, and a blue-toned design token theme in `globals.css`
- Root `/` redirects to `/login`

The right panel collapses on mobile for a responsive single-column form experience.

<a href="https://jurassic-park-1.slack.com/archives/C09AX2SLWTY/p1771874110746909?thread_ts=1771874110.746909&cid=C09AX2SLWTY"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0.app/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0.app/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0.app/chat-static/slack-light.svg" width="108" height="30"></picture></a>