### PR TITLE
Add repository summary to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 # test-repo 👀
-Testing woohoo!
-Another test
-Another one
-hello there
-this is super important to add to the readme file.
+
+A monorepo containing a **Next.js** web application and a **Slack AI Assistant** bot.
+
+## Summary
+
+This repository houses two main projects:
+
+### Next.js Web App
+
+The root of the repo is a [Next.js](https://nextjs.org) application bootstrapped with the App Router, [Tailwind CSS](https://tailwindcss.com), and [shadcn/ui](https://ui.shadcn.com) components. It provides the foundation for building a modern, component-driven web interface.
+
+### Slack AI Assistant (`slack-ai-app/`)
+
+A Slack bot built with the [Slack Bolt](https://slack.dev/bolt-js) framework and the [OpenAI Node SDK](https://github.com/openai/openai-node). It listens for channel messages and the `/ask-ai` slash command, sends conversation context to OpenAI, and replies with AI-generated answers — all within Slack.
+
+Key highlights:
+
+- **Event-driven** — responds to messages and slash commands in real time
+- **Thread-aware** — gathers conversation history for richer context
+- **Configurable** — model, system prompt, and max tokens are all tuneable via environment variables
+- **Socket Mode** — works locally without exposing a public URL
+
+See [`slack-ai-app/README.md`](slack-ai-app/README.md) for detailed setup and usage instructions.


### PR DESCRIPTION
The root README had only placeholder text with no context about what the repo contains.

### What changed
- Replaced the bare-bones README with a structured summary covering both projects in the monorepo: the Next.js web app and the Slack AI Assistant bot
- Highlighted the Slack bot's key features (event-driven messaging, thread-aware context, configurable model/prompt, Socket Mode) and linked to `slack-ai-app/README.md` for detailed setup instructions

<a href="https://jurassic-park-1.slack.com/archives/C030AE41VPV/p1772140280833189?thread_ts=1772140280.833189&cid=C030AE41VPV"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0.app/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0.app/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0.app/chat-static/slack-light.svg" width="108" height="30"></picture></a>